### PR TITLE
Member<->Question Mapping&Join

### DIFF
--- a/server/src/main/java/five/group/server/question/controller/QuestionController.java
+++ b/server/src/main/java/five/group/server/question/controller/QuestionController.java
@@ -1,5 +1,7 @@
 package five.group.server.question.controller;
 
+import five.group.server.member.entity.Member;
+import five.group.server.member.service.MemberService;
 import five.group.server.question.dto.QuestionDto;
 import five.group.server.question.entity.Question;
 import five.group.server.question.mapper.QuestionMapper;
@@ -29,9 +31,12 @@ public class QuestionController {
     private final QuestionMapper questionMapper;
     private final QuestionService questionService;
 
-    public QuestionController(QuestionMapper questionMapper, QuestionService questionService) {
+    private final MemberService memberService;
+
+    public QuestionController(QuestionMapper questionMapper, QuestionService questionService, MemberService memberService) {
         this.questionMapper = questionMapper;
         this.questionService = questionService;
+        this.memberService = memberService;
     }
 
     @PostMapping
@@ -39,13 +44,13 @@ public class QuestionController {
 
         Question question = questionMapper.questionPostDtoToQuestion(requestBody);
 
-        Question createdQuestion = questionService.createQuestion(question);
+        questionService.createQuestion(question);
 
-        return new ResponseEntity<>(questionMapper.questionToQuestionResponse(createdQuestion), HttpStatus.CREATED);
+        return new ResponseEntity<>(HttpStatus.CREATED);
     }
 
     @PatchMapping("/{question-id}")
-    public ResponseEntity patchQuestion(@PathVariable("question-id") @Positive Long questionId,
+    public ResponseEntity patchQuestion(@PathVariable("question-id") @Positive long questionId,
                                         @Valid @RequestBody QuestionDto.Patch requestBody) {
 
         requestBody.setQuestionId(questionId);
@@ -53,15 +58,15 @@ public class QuestionController {
         Question updateQuestion =
                 questionService.updateQuestion(questionMapper.questionPatchDtoToQuestion(requestBody));
 
-        return new ResponseEntity<>(questionMapper.questionToQuestionResponse(updateQuestion), HttpStatus.OK);
+        return new ResponseEntity<>(questionMapper.questionToQuestionResponseDto(updateQuestion), HttpStatus.OK);
     }
 
     // 질문 상세 페이지
     @GetMapping("/{question-id}")
-    public ResponseEntity getQuestion(@PathVariable("question-id") @Positive Long questionId) {
+    public ResponseEntity getQuestion(@PathVariable("question-id") @Positive long questionId) {
         Question question = questionService.getQuestion(questionId);
 
-        return new ResponseEntity<>(questionMapper.questionToQuestionResponse(question), HttpStatus.OK);
+        return new ResponseEntity<>(questionMapper.questionToQuestionResponseDto(question), HttpStatus.OK);
     }
 
     // 질문 조회 리스트
@@ -75,7 +80,7 @@ public class QuestionController {
     }
 
     @DeleteMapping("/{question-id}")
-    public ResponseEntity deleteQuestion(@PathVariable("question-id") @Positive Long questionId) {
+    public ResponseEntity deleteQuestion(@PathVariable("question-id") @Positive long questionId) {
 
         questionService.deleteQuestion(questionId);
 

--- a/server/src/main/java/five/group/server/question/dto/QuestionDto.java
+++ b/server/src/main/java/five/group/server/question/dto/QuestionDto.java
@@ -1,7 +1,6 @@
 package five.group.server.question.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import lombok.*;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Positive;
@@ -13,6 +12,7 @@ public class QuestionDto {
 
     // 질문 등록
     @Getter
+    @Setter
     @AllArgsConstructor
     public static class Post {
 
@@ -23,14 +23,16 @@ public class QuestionDto {
         @NotBlank(message = "본문을 입력하세요.")
         @Size(max = 200, message = "본문은 최대 200자까지 입력할 수 있습니다.")
         private String content;
+        private long memberId;
     }
 
     // 질문 수정
     @Getter
+    @Setter
     @AllArgsConstructor
     public static class Patch {
         @Positive
-        private Long questionId;
+        private long questionId;
 
         @NotBlank(message = "타이틀을 입력하세요.")
         @Size(max = 30, message = "제목은 최대 30자까지 입력할 수 있습니다.")
@@ -40,30 +42,19 @@ public class QuestionDto {
         @Size(max = 200, message = "본문은 최대 200자까지 입력할 수 있습니다.")
         private String content;
 
-        public void setQuestionId(Long questionId) {
+        public void setQuestionId(long questionId) {
             this.questionId = questionId;
         }
     }
 
     // 질문 조회
     @Getter
+    @Setter
+    @Builder
     @AllArgsConstructor
     public static class responsePage {
         private String title;
         private String nickname;
         private LocalDateTime createdAt;
-    }
-
-    // 질문 상세조회
-    @Getter
-    @AllArgsConstructor
-    public static class response {
-        private Long questionId;
-        private Long memberId;
-        private String nickName;
-        private String title;
-        private LocalDateTime createdAt;
-        private LocalDateTime modifiedAt;
-        // 답변 response 추가 필요
     }
 }

--- a/server/src/main/java/five/group/server/question/dto/QuestionGetDetailResponse.java
+++ b/server/src/main/java/five/group/server/question/dto/QuestionGetDetailResponse.java
@@ -1,0 +1,19 @@
+package five.group.server.question.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class QuestionGetDetailResponse {
+    private long questionId;
+    private String nickname;
+    private String title;
+    private String content;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+}

--- a/server/src/main/java/five/group/server/question/entity/Question.java
+++ b/server/src/main/java/five/group/server/question/entity/Question.java
@@ -2,6 +2,7 @@ package five.group.server.question.entity;
 
 import five.group.server.audit.Auditable;
 import five.group.server.comment.entity.Comment;
+import five.group.server.member.entity.Member;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -15,7 +16,7 @@ import java.util.List;
 public class Question extends Auditable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long questionId;
+    private long questionId;
 
     @Column(nullable = false)
     private String title;
@@ -23,20 +24,19 @@ public class Question extends Auditable {
     @Column(nullable = false)
     private String content;
 
+    @Column(nullable = false)
+    private boolean isDeleted;
+
     @Enumerated(value = EnumType.STRING)
     @Column(nullable = false)
     private QuestionStatus questionStatus = QuestionStatus.QUESTION_POSTED;
 
-    //    @ManyToOne
-//    @JoinColumn(name = "memberId")
-//    private Member member;
-//
-//    @OneToMany(mappedBy = "question", cascade = CascadeType.REMOVE)
+    @ManyToOne
+    @JoinColumn(name = "memberId")
+    private Member member;
+
+    //    @OneToMany(mappedBy = "question", cascade = CascadeType.REMOVE)
 //    private List<Answer> answers;
-
-    @OneToMany(mappedBy = "question", cascade = CascadeType.REMOVE)
-    private List<Comment> comments;
-
     public enum QuestionStatus {
         QUESTION_POSTED("글 작성"),
         QUESTION_DELETE("글 삭제됨");

--- a/server/src/main/java/five/group/server/question/mapper/QuestionMapper.java
+++ b/server/src/main/java/five/group/server/question/mapper/QuestionMapper.java
@@ -1,15 +1,43 @@
 package five.group.server.question.mapper;
 
 import five.group.server.question.dto.QuestionDto;
+import five.group.server.question.dto.QuestionGetDetailResponse;
 import five.group.server.question.entity.Question;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 import java.util.List;
 
 @Mapper(componentModel = "spring")
 public interface QuestionMapper {
+    @Mapping(source = "memberId", target = "member.memberId")
     Question questionPostDtoToQuestion(QuestionDto.Post requestBody);
     Question questionPatchDtoToQuestion(QuestionDto.Patch requestBody);
-    QuestionDto.response questionToQuestionResponse(Question question);
     List<QuestionDto.responsePage> questionsToQuestionList(List<Question> questionList);
+
+    default QuestionDto.responsePage questionsToQuestionListDto(Question question) {
+        QuestionDto.responsePage QuestionListDto =
+                QuestionDto.responsePage.builder()
+                        .title(question.getTitle())
+                        .nickname(question.getMember().getNickname())
+                        .createdAt(question.getCreatedAt())
+                        .build();
+
+        return QuestionListDto;
+    }
+
+    // 답변이 존재할 경우 답변 response 를 담아서 반환하는 로직 구현 필요
+    default QuestionGetDetailResponse questionToQuestionResponseDto(Question question) {
+        QuestionGetDetailResponse questionResponseDto =
+                QuestionGetDetailResponse.builder()
+                        .questionId(question.getQuestionId())
+                        .nickname(question.getMember().getNickname())
+                        .title(question.getTitle())
+                        .content(question.getContent())
+                        .createdAt(question.getCreatedAt())
+                        .modifiedAt(question.getModifiedAt())
+                        .build();
+
+        return questionResponseDto;
+    }
 }

--- a/server/src/main/java/five/group/server/question/repository/QuestionRepository.java
+++ b/server/src/main/java/five/group/server/question/repository/QuestionRepository.java
@@ -4,6 +4,10 @@ import five.group.server.question.entity.Question;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
+
 @Repository
 public interface QuestionRepository extends JpaRepository<Question, Long> {
+    List<Question> findByMemberId(long memberId);
 }

--- a/server/src/main/java/five/group/server/question/service/QuestionService.java
+++ b/server/src/main/java/five/group/server/question/service/QuestionService.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -36,7 +37,7 @@ public class QuestionService {
         return questionRepository.save(getQuestion);
     }
 
-    public Question getQuestion(Long questionId) {
+    public Question getQuestion(long questionId) {
         return findVerifiedQuestion(questionId);
     }
 
@@ -47,16 +48,27 @@ public class QuestionService {
         return questionRepository.findAll(pageRequest);
     }
 
-    public void deleteQuestion (Long questionId) {
+    public void deleteQuestion (long questionId) {
         Question verifiedQuestion = findVerifiedQuestion(questionId);
         questionRepository.delete(verifiedQuestion);
     }
 
-    public Question findVerifiedQuestion(Long questionId) {
+    // delete 된 질문은 조회 제외 로직이 필요(?)
+    public Question findVerifiedQuestion(long questionId) {
         Optional<Question> optionalQuestion = questionRepository.findById(questionId);
         Question findQuestion = optionalQuestion.orElseThrow(() ->
                 new BusinessLogicException(ExceptionCode.QUESTION_NOT_FOUND));
 
         return findQuestion;
+    }
+
+//     memberId로 질문 조회
+    public List<Question> getMemberId(long memberId) {
+        List<Question> memberIdToQuestion = questionRepository.findByMemberId(memberId);
+
+        if (memberIdToQuestion.isEmpty()) {
+            throw new BusinessLogicException(ExceptionCode.QUESTION_NOT_FOUND);
+        }
+        return memberIdToQuestion;
     }
 }

--- a/server/src/main/java/five/group/server/question/service/QuestionService.java
+++ b/server/src/main/java/five/group/server/question/service/QuestionService.java
@@ -13,6 +13,9 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.Optional;
 
+import static five.group.server.exception.ExceptionCode.MEMBER_DELETED;
+import static five.group.server.exception.ExceptionCode.QUESTION_DELETED;
+
 @Service
 public class QuestionService {
     private final QuestionRepository questionRepository;
@@ -53,12 +56,14 @@ public class QuestionService {
         questionRepository.delete(verifiedQuestion);
     }
 
-    // delete 된 질문은 조회 제외 로직이 필요(?)
     public Question findVerifiedQuestion(long questionId) {
         Optional<Question> optionalQuestion = questionRepository.findById(questionId);
         Question findQuestion = optionalQuestion.orElseThrow(() ->
                 new BusinessLogicException(ExceptionCode.QUESTION_NOT_FOUND));
 
+        if (findQuestion.getQuestionStatus().getStatus().equals("QUESTION_DELETE")) {
+            throw new BusinessLogicException(QUESTION_DELETED);
+        }
         return findQuestion;
     }
 


### PR DESCRIPTION
1. Question Post 시 반환되는 값 수정 (Response + HttpStatus -> HttpStatus)
2. Question GET 요청 시 Member 요소를 사용하기 위해 QuestionGetDetailResponse Dto클래스 추가 및 수동으로 매핑
3. Long questionId -> long questionId
4. memberId로 질문조회 가능한 메서드 추가

5. 질문 조회 시 작성자 연결을 위해 get response에 memberId 추가
   -> 현재 코드로 Question POST 시 요청하는 인자로써 {"memberId", "title", "content"} 전달
       (개선 가능여부 검토 필요)
6. 질문 조회 시, delete 된 질문은 조회 안하는 로직 필요 의견 접수
    -> delete 된 질문은 조회 대상에서 제외시키는 로직이 이미 존재
       (로직 수정 재검토 필요)